### PR TITLE
Fix broken link

### DIFF
--- a/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/MeadowWindowControl.xaml.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/MeadowWindowControl.xaml.cs
@@ -159,7 +159,7 @@
             else
             {
                 OutputMessage("Device not found. Connect the device in bootloader mode by plugging in the device while holding down the BOOT button.");
-                OutputMessage("For more help, visit http://developer.wildernesslabs.co/Meadow/Getting_Started/Troubleshooting/VS");
+                OutputMessage("For more help, visit http://developer.wildernesslabs.co/Meadow/Meadow_Basics/Troubleshooting/VisualStudio/");
             }
 
             RefreshDeviceList();


### PR DESCRIPTION
The current link just sends you to the default documentation landing page. It looks like the right link for the VS documentation is

> http://developer.wildernesslabs.co/Meadow/Meadow_Basics/Troubleshooting/VisualStudio/

So I updated it to that.