### PR TITLE
Add timings to deployment logs

### DIFF
--- a/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/DeployProvider.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/DeployProvider.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnvDTE;
 using Meadow.Helpers;
+using Meadow.Utility;
 using MeadowCLI.DeviceManagement;
 using MeadowCLI.Hcom;
 using Microsoft.VisualStudio;
@@ -48,10 +49,10 @@ namespace Meadow
                 throw new Exception($"Device on '{settings.DeviceTarget}' is not connected or busy.");
             }
 
-            await DeployAppAsync(settings.DeviceTarget, Path.Combine(projectDir, outputPath), outputPaneWriter, cts);
+            await DeployAppAsync(settings.DeviceTarget, Path.Combine(projectDir, outputPath), new OutputPaneWriter(outputPaneWriter), cts);
         }
 
-        async Task DeployAppAsync(string target, string folder, TextWriter outputPaneWriter, CancellationToken cts)
+        async Task DeployAppAsync(string target, string folder, IOutputPaneWriter outputPaneWriter, CancellationToken cts)
         {
             await outputPaneWriter.WriteAsync($"Deploying to Meadow on {target}...");
 
@@ -85,7 +86,7 @@ namespace Meadow
             }
         }
 
-        async Task<bool> InitializeMeadowDeviceAsync(MeadowSerialDevice meadow, TextWriter outputPaneWriter, CancellationToken cts)
+        async Task<bool> InitializeMeadowDeviceAsync(MeadowSerialDevice meadow, IOutputPaneWriter outputPaneWriter, CancellationToken cts)
         {
             if (cts.IsCancellationRequested) return true;
 
@@ -116,7 +117,7 @@ namespace Meadow
             return true;
         }
 
-        async Task<(List<string> files, List<UInt32> crcs)> GetFilesOnDevice(MeadowSerialDevice meadow, TextWriter outputPaneWriter, CancellationToken cts)
+        async Task<(List<string> files, List<UInt32> crcs)> GetFilesOnDevice(MeadowSerialDevice meadow, IOutputPaneWriter outputPaneWriter, CancellationToken cts)
         {
             if (cts.IsCancellationRequested) { return (new List<string>(), new List<UInt32>()); }
 
@@ -138,7 +139,7 @@ namespace Meadow
             return meadowFiles;
         }
 
-        async Task<(List<string> files, List<UInt32> crcs)> GetLocalFiles(TextWriter outputPaneWriter, CancellationToken cts, string folder)
+        async Task<(List<string> files, List<UInt32> crcs)> GetLocalFiles(IOutputPaneWriter outputPaneWriter, CancellationToken cts, string folder)
         {
             // get list of files in folder
             // var files = Directory.GetFiles(folder, "*.dll");
@@ -177,7 +178,7 @@ namespace Meadow
             return (files, crcs);
         }
 
-        async Task DeleteUnusedFiles(MeadowSerialDevice meadow, TextWriter outputPaneWriter, CancellationToken cts,
+        async Task DeleteUnusedFiles(MeadowSerialDevice meadow, IOutputPaneWriter outputPaneWriter, CancellationToken cts,
             (List<string> files, List<UInt32> crcs) meadowFiles, (List<string> files, List<UInt32> crcs) localFiles)
         {
             if (cts.IsCancellationRequested)
@@ -195,7 +196,7 @@ namespace Meadow
             }
         }
 
-        async Task DeployApp(MeadowSerialDevice meadow, TextWriter outputPaneWriter, CancellationToken cts, string folder,
+        async Task DeployApp(MeadowSerialDevice meadow, IOutputPaneWriter outputPaneWriter, CancellationToken cts, string folder,
             (List<string> files, List<UInt32> crcs) meadowFiles, (List<string> files, List<UInt32> crcs) localFiles)
         {
             if (cts.IsCancellationRequested)
@@ -209,7 +210,7 @@ namespace Meadow
             }
         }
 
-        async Task<List<string>> GetFilesOnDeviceAsync(MeadowSerialDevice meadow, TextWriter outputPaneWriter, CancellationToken cts)
+        async Task<List<string>> GetFilesOnDeviceAsync(MeadowSerialDevice meadow, IOutputPaneWriter outputPaneWriter, CancellationToken cts)
         {
             if (cts.IsCancellationRequested) { return new List<string>(); }
 
@@ -225,7 +226,7 @@ namespace Meadow
             return files;
         }
 
-        async Task WriteFileToMeadowAsync(MeadowSerialDevice meadow, TextWriter outputPaneWriter, CancellationToken cts, string folder, string file, bool overwrite = false)
+        async Task WriteFileToMeadowAsync(MeadowSerialDevice meadow, IOutputPaneWriter outputPaneWriter, CancellationToken cts, string folder, string file, bool overwrite = false)
         {
             if (cts.IsCancellationRequested) { return; }
 
@@ -236,7 +237,7 @@ namespace Meadow
             }
         }
 
-        async Task ResetMeadowAndStartMonoAsync(MeadowSerialDevice meadow, TextWriter outputPaneWriter, CancellationToken cts)
+        async Task ResetMeadowAndStartMonoAsync(MeadowSerialDevice meadow, IOutputPaneWriter outputPaneWriter, CancellationToken cts)
         {
             if (cts.IsCancellationRequested) { return; }
 

--- a/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/DeployProvider.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/DeployProvider.cs
@@ -54,6 +54,7 @@ namespace Meadow
 
         async Task DeployAppAsync(string target, string folder, IOutputPaneWriter outputPaneWriter, CancellationToken cts)
         {
+            Stopwatch sw = Stopwatch.StartNew();
             await outputPaneWriter.WriteAsync($"Deploying to Meadow on {target}...");
 
             try
@@ -84,6 +85,9 @@ namespace Meadow
             {
                 throw ex;
             }
+
+            sw.Stop();
+            await outputPaneWriter.WriteAsync($"Deployment Duration: {sw.Elapsed}");
         }
 
         async Task<bool> InitializeMeadowDeviceAsync(MeadowSerialDevice meadow, IOutputPaneWriter outputPaneWriter, CancellationToken cts)
@@ -131,7 +135,7 @@ namespace Meadow
                 await outputPaneWriter.WriteAsync($"Found {f}").ConfigureAwait(false);
             }
 
-            if(meadowFiles.files.Count == 0)
+            if (meadowFiles.files.Count == 0)
             {
                 await outputPaneWriter.WriteAsync($"Deploying for the first time may take several minutes.").ConfigureAwait(false);
             }

--- a/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/Utility/OutputPaneWriter.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/Utility/OutputPaneWriter.cs
@@ -38,6 +38,7 @@ namespace Meadow.Utility
             else
             {
                 await this.textWriter.WriteAsync($"{CurrentTimeStamp} {text}").ConfigureAwait(false);
+                this.stopwatch.Start();
             }
         }
     }

--- a/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/Utility/OutputPaneWriter.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/Utility/OutputPaneWriter.cs
@@ -26,18 +26,20 @@ namespace Meadow.Utility
             this.stopwatch = new Stopwatch();
         }
 
-        public string CurrentTimeStamp => DateTime.Now.ToLocalTime().ToString();
+        public string CurrentTimeStamp => $"[{DateTime.Now.ToLocalTime()}]";
+
+        public string ElapsedTime => $"({this.stopwatch.Elapsed} since last.)";
 
         public async Task WriteAsync(string text)
         {
             if (this.stopwatch.IsRunning)
             {
-                await this.textWriter.WriteAsync($"{CurrentTimeStamp} {text} ({this.stopwatch.Elapsed} since last log.)").ConfigureAwait(false);
+                await this.textWriter.WriteAsync($"{CurrentTimeStamp,-25} {text,-120} {ElapsedTime}").ConfigureAwait(false);
                 this.stopwatch.Restart();
             }
             else
             {
-                await this.textWriter.WriteAsync($"{CurrentTimeStamp} {text}").ConfigureAwait(false);
+                await this.textWriter.WriteAsync($"{CurrentTimeStamp,-25} {text,-120}").ConfigureAwait(false);
                 this.stopwatch.Start();
             }
         }

--- a/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/Utility/OutputPaneWriter.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/Utility/OutputPaneWriter.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Meadow.Utility
+{
+    interface IOutputPaneWriter
+    {
+        Task WriteAsync(string text);
+    }
+
+    class OutputPaneWriter : IOutputPaneWriter
+    {
+        private readonly TextWriter textWriter;
+        private readonly Stopwatch stopwatch;
+
+        public OutputPaneWriter(TextWriter textWriter)
+        {
+            if (textWriter is null)
+            {
+                throw new ArgumentNullException(nameof(textWriter));
+            }
+
+            this.textWriter = textWriter;
+            this.stopwatch = new Stopwatch();
+        }
+
+        public string CurrentTimeStamp => DateTime.Now.ToLocalTime().ToString();
+
+        public async Task WriteAsync(string text)
+        {
+            if (this.stopwatch.IsRunning)
+            {
+                await this.textWriter.WriteAsync($"{CurrentTimeStamp} {text} ({this.stopwatch.Elapsed} since last log.)").ConfigureAwait(false);
+                this.stopwatch.Restart();
+            }
+            else
+            {
+                await this.textWriter.WriteAsync($"{CurrentTimeStamp} {text}").ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/VS_Meadow_Extension.ProjectType.csproj
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.ProjectType/VS_Meadow_Extension.ProjectType.csproj
@@ -373,6 +373,7 @@
     <Compile Include="ProjectProperties.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="STDfuDevice.cs" />
+    <Compile Include="Utility\OutputPaneWriter.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="libusb-1.0.dll" />


### PR DESCRIPTION
This is a PR for #4 that adds both timestamp and duration to the deployment logs. Here's what it looks like:

![image](https://user-images.githubusercontent.com/578591/71685363-ef133800-2d4c-11ea-959b-aa9bcaedb3e5.png)

I went with a fixed width string formatting to allow for the durations to line up; without it I thought it was hard to read the output.