### PR TITLE
Have the devices appear in a Toolbar dropdown list.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,10 +24,12 @@ jobs:
         path: Meadow.CLI
         ref: develop
 
-    - name: Setup .NET Core SDK 5.0.x
+    - name: Setup .NET Core SDK 5.0.x and 6.0.x
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: |
+          5.0.x
+          6.0.x
 
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
@@ -69,10 +71,12 @@ jobs:
         path: Meadow.CLI
         ref: develop
 
-    - name: Setup .NET Core SDK 5.0.x
+    - name: Setup .NET Core SDK 5.0.x and 6.0.x
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: |
+          5.0.x
+          6.0.x
 
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5

--- a/VS_Meadow_Extension/VS_Meadow_Extension.2019/VS_Meadow_Extension.2019.csproj
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.2019/VS_Meadow_Extension.2019.csproj
@@ -209,16 +209,6 @@
     <Compile Include="..\VS_Meadow_Extension.Shared\MeadowSettings.cs">
       <Link>MeadowSettings.cs</Link>
     </Compile>
-    <Compile Include="..\VS_Meadow_Extension.Shared\MeadowWindow.cs">
-      <Link>MeadowWindow.cs</Link>
-    </Compile>
-    <Compile Include="..\VS_Meadow_Extension.Shared\MeadowWindowCommand.cs">
-      <Link>MeadowWindowCommand.cs</Link>
-    </Compile>
-    <Compile Include="..\VS_Meadow_Extension.Shared\MeadowWindowControl.xaml.cs">
-      <DependentUpon>MeadowWindowControl.xaml</DependentUpon>
-      <Link>MeadowWindowControl.xaml.cs</Link>
-    </Compile>
     <Compile Include="..\VS_Meadow_Extension.Shared\ProjectProperties.cs">
       <Link>ProjectProperties.cs</Link>
     </Compile>

--- a/VS_Meadow_Extension/VS_Meadow_Extension.2019/VS_Meadow_Extension.2019.csproj
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.2019/VS_Meadow_Extension.2019.csproj
@@ -339,11 +339,6 @@
       <SubType>Designer</SubType>
       <Link>BuildSystem\Rules\MeadowDebugger.xaml</Link>
     </XamlPropertyRule>
-    <Page Include="..\VS_Meadow_Extension.Shared\MeadowWindowControl.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-      <Link>MeadowWindowControl.xaml</Link>
-    </Page>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Meadow.CLI\Meadow.CLI.Core\Meadow.CLI.Core.VS2019.csproj">

--- a/VS_Meadow_Extension/VS_Meadow_Extension.2022/VS_Meadow_Extension.2022.csproj
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.2022/VS_Meadow_Extension.2022.csproj
@@ -340,11 +340,6 @@
       <SubType>Designer</SubType>
       <Link>BuildSystem\Rules\MeadowDebugger.xaml</Link>
     </XamlPropertyRule>
-    <Page Include="..\VS_Meadow_Extension.Shared\MeadowWindowControl.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-      <Link>MeadowWindowControl.xaml</Link>
-    </Page>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Meadow.CLI\Meadow.CLI.Core\Meadow.CLI.Core.VS2019.csproj">

--- a/VS_Meadow_Extension/VS_Meadow_Extension.2022/VS_Meadow_Extension.2022.csproj
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.2022/VS_Meadow_Extension.2022.csproj
@@ -210,16 +210,6 @@
     <Compile Include="..\VS_Meadow_Extension.Shared\MeadowSettings.cs">
       <Link>MeadowSettings.cs</Link>
     </Compile>
-    <Compile Include="..\VS_Meadow_Extension.Shared\MeadowWindow.cs">
-      <Link>MeadowWindow.cs</Link>
-    </Compile>
-    <Compile Include="..\VS_Meadow_Extension.Shared\MeadowWindowCommand.cs">
-      <Link>MeadowWindowCommand.cs</Link>
-    </Compile>
-    <Compile Include="..\VS_Meadow_Extension.Shared\MeadowWindowControl.xaml.cs">
-      <DependentUpon>MeadowWindowControl.xaml</DependentUpon>
-      <Link>MeadowWindowControl.xaml.cs</Link>
-    </Compile>
     <Compile Include="..\VS_Meadow_Extension.Shared\ProjectProperties.cs">
       <Link>ProjectProperties.cs</Link>
     </Compile>

--- a/VS_Meadow_Extension/VS_Meadow_Extension.Shared/DeployProvider.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.Shared/DeployProvider.cs
@@ -121,10 +121,9 @@ namespace Meadow
 
             IVsOutputWindow outWindow = Package.GetGlobalService(typeof(SVsOutputWindow)) as IVsOutputWindow;
             Guid generalPaneGuid = VSConstants.GUID_OutWindowDebugPane; // P.S. There's also the GUID_OutWindowDebugPane available.
-            
-            IVsOutputWindowPane generalPane;
-            outWindow.GetPane(ref generalPaneGuid, out generalPane);
-            generalPane.Activate();
+
+			outWindow.GetPane(ref generalPaneGuid, out IVsOutputWindowPane generalPane);
+			generalPane.Activate();
             generalPane.Clear();
 
             generalPane.OutputString(" Launching application..." + Environment.NewLine);

--- a/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowDebuggerLaunchProvider.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowDebuggerLaunchProvider.cs
@@ -64,19 +64,28 @@ namespace Meadow
             DeployProvider.Meadow?.Dispose();
 
             var device = await MeadowProvider.GetMeadowSerialDeviceAsync(logger: outputPane);
-            DeployProvider.Meadow = new MeadowDeviceHelper(device, outputPane);
 
-            var meadowSession = new MeadowSoftDebuggerSession(DeployProvider.Meadow);
+            if (device != null)
+            {
+                DeployProvider.Meadow = new MeadowDeviceHelper(device, outputPane);
 
-            var startArgs = new SoftDebuggerConnectArgs(profile.Name, IPAddress.Loopback, 55898);
-            var startInfo = new StartInfo(startArgs, debuggingOptions, VsHierarchy.GetProject());
+                var meadowSession = new MeadowSoftDebuggerSession(DeployProvider.Meadow);
 
-            var sessionInfo = new SessionMarshalling(meadowSession, startInfo);
-            vsSession = new DebuggerSession(startInfo, outputPane, meadowSession, this);
+                var startArgs = new SoftDebuggerConnectArgs(profile.Name, IPAddress.Loopback, 55898);
+                var startInfo = new StartInfo(startArgs, debuggingOptions, VsHierarchy.GetProject());
 
-            var settings = new MonoDebugLaunchSettings(launchOptions, sessionInfo);
+                var sessionInfo = new SessionMarshalling(meadowSession, startInfo);
+                vsSession = new DebuggerSession(startInfo, outputPane, meadowSession, this);
 
-            return new[] { settings };
+                var settings = new MonoDebugLaunchSettings(launchOptions, sessionInfo);
+
+                return new[] { settings };
+            }
+            else
+			{
+                vsSession = null;
+                return Array.Empty<IDebugLaunchSettings>();
+            }
         }
 
         public Task OnBeforeLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile) => Task.CompletedTask;

--- a/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.cs
@@ -46,6 +46,8 @@ namespace Meadow
     [Guid(GuidList.guidMeadowPackageString)]
     public sealed class MeadowPackage : AsyncPackage
     {
+        private const string NoDevicesFound = "No Devices Found";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MeadowPackage"/> class.
         /// </summary>
@@ -73,17 +75,17 @@ namespace Meadow
             // Do any initialization that requires the UI thread after switching to the UI thread.
             await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-			// Add our command handlers for menu (commands must be declared in the .vsct file)
-			if (await GetServiceAsync(typeof(IMenuCommandService)) is OleMenuCommandService mcs)
-			{
-				CommandID menuMeadowDeviceListComboCommandID = new CommandID(GuidList.guidMeadowPackageCmdSet, (int)PkgCmdIDList.cmdidMeadowDeviceListCombo);
-				OleMenuCommand menuMeadowDeviceListComboCommand = new OleMenuCommand(new EventHandler(OnMeadowDeviceListCombo), menuMeadowDeviceListComboCommandID);
-				mcs.AddCommand(menuMeadowDeviceListComboCommand);
+            // Add our command handlers for menu (commands must be declared in the .vsct file)
+            if (await GetServiceAsync(typeof(IMenuCommandService)) is OleMenuCommandService mcs)
+            {
+                CommandID menuMeadowDeviceListComboCommandID = new CommandID(GuidList.guidMeadowPackageCmdSet, (int)PkgCmdIDList.cmdidMeadowDeviceListCombo);
+                OleMenuCommand menuMeadowDeviceListComboCommand = new OleMenuCommand(new EventHandler(OnMeadowDeviceListCombo), menuMeadowDeviceListComboCommandID);
+                mcs.AddCommand(menuMeadowDeviceListComboCommand);
 
-				CommandID menuMeadowDeviceListComboGetListCommandID = new CommandID(GuidList.guidMeadowPackageCmdSet, (int)PkgCmdIDList.cmdidMeadowDeviceListComboGetList);
-				MenuCommand menuMeadowDeviceListComboGetListCommand = new OleMenuCommand(new EventHandler(OnMeadowDeviceListComboGetList), menuMeadowDeviceListComboGetListCommandID);
-				mcs.AddCommand(menuMeadowDeviceListComboGetListCommand);
-			}
+                CommandID menuMeadowDeviceListComboGetListCommandID = new CommandID(GuidList.guidMeadowPackageCmdSet, (int)PkgCmdIDList.cmdidMeadowDeviceListComboGetList);
+                MenuCommand menuMeadowDeviceListComboGetListCommand = new OleMenuCommand(new EventHandler(OnMeadowDeviceListComboGetList), menuMeadowDeviceListComboGetListCommandID);
+                mcs.AddCommand(menuMeadowDeviceListComboGetListCommand);
+            }
         }
         #endregion
 
@@ -91,9 +93,9 @@ namespace Meadow
         {
             if (e is OleMenuCmdEventArgs eventArgs)
             {
-				IntPtr vOut = eventArgs.OutValue;
+                IntPtr vOut = eventArgs.OutValue;
 
-				if (vOut != IntPtr.Zero)
+                if (vOut != IntPtr.Zero)
                 {
                     string deviceTarget = string.Empty;
                     var portList = MeadowDeviceManager.GetSerialPorts();
@@ -107,11 +109,11 @@ namespace Meadow
                 }
                 else if (eventArgs.InValue is string newChoice)
                 {
-                    // new value was selected check if it is our list
+                    // new value was selected check if it is in our list
                     bool validInput = false;
                     var portList = MeadowDeviceManager.GetSerialPorts();
-					for (int i = 0; i < portList.Count; i++)
-					{
+                    for (int i = 0; i < portList.Count; i++)
+                    {
                         if (string.Compare(portList[i], newChoice, StringComparison.CurrentCultureIgnoreCase) == 0)
                         {
                             validInput = true;
@@ -121,15 +123,11 @@ namespace Meadow
 
                     if (validInput)
                     {
-						MeadowSettings settings = new MeadowSettings(Globals.SettingsFilePath, false)
-						{
-							DeviceTarget = newChoice
-						};
-						settings.Save();
-                    }
-                    else
-                    {
-                        throw (new ArgumentException("Invalid Device Selected")); // force an exception to be thrown
+                        MeadowSettings settings = new MeadowSettings(Globals.SettingsFilePath, false)
+                        {
+                            DeviceTarget = newChoice
+                        };
+                        settings.Save();
                     }
                 }
             }
@@ -160,7 +158,7 @@ namespace Meadow
                     }
                     else
                     {
-                        Marshal.GetNativeVariantForObject(new string [] { "No Devices Found" }, vOut);
+                        Marshal.GetNativeVariantForObject(new string[] { NoDevicesFound }, vOut);
                     }
                 }
                 else

--- a/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.cs
@@ -128,7 +128,14 @@ namespace Meadow
                             DeviceTarget = newChoice
                         };
                         settings.Save();
-                    }
+					}
+					else
+					{
+                        if (!newChoice.Equals(NoDevicesFound))
+						{
+                            throw (new ArgumentException("Invalid Device Selected"));
+                        }
+					}
                 }
             }
             else

--- a/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.cs
@@ -44,8 +44,6 @@ namespace Meadow
     [InstalledProductRegistration("#1110", "#1112", "1.0", IconResourceID = 1400)] // Info on this package for Help/About
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(GuidList.guidMeadowPackageString)]
-    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
-    [ProvideToolWindow(typeof(MeadowWindow))]
     public sealed class MeadowPackage : AsyncPackage
     {
         /// <summary>
@@ -86,8 +84,6 @@ namespace Meadow
 				MenuCommand menuMeadowDeviceListComboGetListCommand = new OleMenuCommand(new EventHandler(OnMeadowDeviceListComboGetList), menuMeadowDeviceListComboGetListCommandID);
 				mcs.AddCommand(menuMeadowDeviceListComboGetListCommand);
 			}
-
-			await MeadowWindowCommand.InitializeAsync(this);
         }
         #endregion
 

--- a/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.vsct
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.vsct
@@ -80,13 +80,6 @@
               <CommandFlag>DefaultInvisible</CommandFlag>
               <CommandFlag>DynamicVisibility</CommandFlag>
           If you do not want an image next to your command, remove the Icon node /> -->
-      <Button guid="guidMeadowPackageCmdSet" id="cmdidMeadowWindowCommand" priority="0x0100" type="Button">
-        <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1" />
-        <Icon guid="guidImages1" id="bmpPic1" />
-        <Strings>
-          <ButtonText>Meadow</ButtonText>
-        </Strings>
-      </Button>
     </Buttons>
 
     <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->

--- a/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.vsct
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.vsct
@@ -111,10 +111,6 @@
       <Parent guid="guidMeadowPackageCmdSet" id="MyToolbar"/>
     </CommandPlacement>
   </CommandPlacements>
-
-  <KeyBindings>
-    <KeyBinding guid="guidMeadowPackageCmdSet" id="cmdidMeadowWindowCommand" editor="guidVSStd97" key1="M" mod1="Control Shift" />
-  </KeyBindings>
   
   <Symbols>
     <!-- This is the package guid. -->

--- a/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.vsct
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.vsct
@@ -38,7 +38,7 @@
       and toolbars (both toolwindow and top-level). A menu is a container for groups. -->
       <Menu guid="guidMeadowPackageCmdSet" id="MyToolbar" priority="0x0000" type="Toolbar">
         <Strings>
-          <ButtonText>Meadow Device Combobox</ButtonText>
+          <ButtonText>Meadow Device List</ButtonText>
         </Strings>
       </Menu>
     </Menus>
@@ -48,23 +48,23 @@
          group as the part of a menu contained between two lines. The parent of a group
          must be a menu. -->
     <Groups>
-      <Group guid="guidMeadowPackageCmdSet" id="MyMenuGroup" priority="0x0600">
+      <Group guid="guidMeadowPackageCmdSet" id="MeadowMenuGroup" priority="0x0600">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_TOOLS" />
       </Group>
     </Groups>
 
     <Combos>
       <Combo guid="guidMeadowPackageCmdSet" id="cmdidMeadowDeviceListCombo" priority="0x0010" type="DropDownCombo" defaultWidth="70" idCommandList="cmdidMeadowDeviceListComboGetList">
-        <Parent guid="guidMeadowPackageCmdSet" id="MyToolbarGroup"/>
+        <Parent guid="guidMeadowPackageCmdSet" id="MeadowMenuGroup"/>
         <CommandFlag>IconAndText</CommandFlag>
         <CommandFlag>CommandWellOnly</CommandFlag>
         <Strings>
-          <MenuText>DropDown Combo: </MenuText>
-          <ButtonText>DropDown: </ButtonText>
-          <ToolTipText>Select String</ToolTipText>
-          <CanonicalName>DropDown Combo</CanonicalName>
-          <LocCanonicalName>DropDown Combo</LocCanonicalName>
-          <CommandName>DropDown Combo</CommandName>
+          <MenuText>Meadow Devices: </MenuText>
+          <ButtonText>Meadow Devices: </ButtonText>
+          <ToolTipText>Select Device</ToolTipText>
+          <CanonicalName>Meadow Devices</CanonicalName>
+          <LocCanonicalName>Meadow Devices</LocCanonicalName>
+          <CommandName>Meadow Devices</CommandName>
         </Strings>
       </Combo>
     </Combos>
@@ -106,8 +106,8 @@
   groups. For instance, it is possible to place one of VisualStudio's menus or commands inside one of our  
   groups or one of our groups inside a menu defined somewhere else. -->
   <CommandPlacements>
-    <!-- Place our group (MyToolbarGroup) onto our toolbar (MyToolbar)-->
-    <CommandPlacement guid="guidMeadowPackageCmdSet" id="MyToolbarGroup" priority="0x0100">
+    <!-- Place our group (MeadowMenuGroup) onto our toolbar (MyToolbar)-->
+    <CommandPlacement guid="guidMeadowPackageCmdSet" id="MeadowMenuGroup" priority="0x0100">
       <Parent guid="guidMeadowPackageCmdSet" id="MyToolbar"/>
     </CommandPlacement>
   </CommandPlacements>
@@ -122,9 +122,8 @@
 
     <!-- This is the guid used to group the menu commands together -->
     <GuidSymbol name="guidMeadowPackageCmdSet" value="{0af06414-3c09-44ff-88a1-c4e1a35b0bdf}">
-      <IDSymbol name="MyMenuGroup" value="0x1020" />
+      <IDSymbol name="MeadowMenuGroup" value="0x1020" />
       <IDSymbol name="MyToolbar" value="0x1000"/>
-      <IDSymbol name="MyToolbarGroup" value="0x1030"/>
       <IDSymbol name="Command2Id" value="0x0100" />
       <IDSymbol name="cmdidMeadowWindowCommand" value="4129" />
       <IDSymbol name="cmdidMeadowDeviceListCombo" value="0x101"/>

--- a/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.vsct
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.Shared/MeadowPackage.vsct
@@ -31,6 +31,18 @@
     group; your package should define its own command set in order to avoid collisions
     with command ids defined by other packages. -->
 
+    <Menus>
+
+      <!--In this section you can define new menus. A menu in VS is the generic way of
+      refering to both menus (all types, including context menus and MenuControllers)
+      and toolbars (both toolwindow and top-level). A menu is a container for groups. -->
+      <Menu guid="guidMeadowPackageCmdSet" id="MyToolbar" priority="0x0000" type="Toolbar">
+        <Strings>
+          <ButtonText>Meadow Device Combobox</ButtonText>
+        </Strings>
+      </Menu>
+    </Menus>
+
     <!-- In this section you can define new menu groups. A menu group is a container for
          other menus or buttons (commands); from a visual point of view you can see the
          group as the part of a menu contained between two lines. The parent of a group
@@ -40,6 +52,22 @@
         <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_TOOLS" />
       </Group>
     </Groups>
+
+    <Combos>
+      <Combo guid="guidMeadowPackageCmdSet" id="cmdidMeadowDeviceListCombo" priority="0x0010" type="DropDownCombo" defaultWidth="70" idCommandList="cmdidMeadowDeviceListComboGetList">
+        <Parent guid="guidMeadowPackageCmdSet" id="MyToolbarGroup"/>
+        <CommandFlag>IconAndText</CommandFlag>
+        <CommandFlag>CommandWellOnly</CommandFlag>
+        <Strings>
+          <MenuText>DropDown Combo: </MenuText>
+          <ButtonText>DropDown: </ButtonText>
+          <ToolTipText>Select String</ToolTipText>
+          <CanonicalName>DropDown Combo</CanonicalName>
+          <LocCanonicalName>DropDown Combo</LocCanonicalName>
+          <CommandName>DropDown Combo</CommandName>
+        </Strings>
+      </Combo>
+    </Combos>
 
     <!--Buttons section. -->
     <!--This section defines the elements the user can interact with, like a menu command or a button
@@ -74,6 +102,16 @@
     
   </Commands>
 
+  <!--Inside this section, we have the ability to place groups inside menus or menus / commands inside
+  groups. For instance, it is possible to place one of VisualStudio's menus or commands inside one of our  
+  groups or one of our groups inside a menu defined somewhere else. -->
+  <CommandPlacements>
+    <!-- Place our group (MyToolbarGroup) onto our toolbar (MyToolbar)-->
+    <CommandPlacement guid="guidMeadowPackageCmdSet" id="MyToolbarGroup" priority="0x0100">
+      <Parent guid="guidMeadowPackageCmdSet" id="MyToolbar"/>
+    </CommandPlacement>
+  </CommandPlacements>
+
   <KeyBindings>
     <KeyBinding guid="guidMeadowPackageCmdSet" id="cmdidMeadowWindowCommand" editor="guidVSStd97" key1="M" mod1="Control Shift" />
   </KeyBindings>
@@ -85,8 +123,12 @@
     <!-- This is the guid used to group the menu commands together -->
     <GuidSymbol name="guidMeadowPackageCmdSet" value="{0af06414-3c09-44ff-88a1-c4e1a35b0bdf}">
       <IDSymbol name="MyMenuGroup" value="0x1020" />
+      <IDSymbol name="MyToolbar" value="0x1000"/>
+      <IDSymbol name="MyToolbarGroup" value="0x1030"/>
       <IDSymbol name="Command2Id" value="0x0100" />
-      <IDSymbol value="4129" name="cmdidMeadowWindowCommand" />
+      <IDSymbol name="cmdidMeadowWindowCommand" value="4129" />
+      <IDSymbol name="cmdidMeadowDeviceListCombo" value="0x101"/>
+      <IDSymbol name="cmdidMeadowDeviceListComboGetList" value="0x102"/>
     </GuidSymbol>
 
     <GuidSymbol name="guidImages" value="{1e20ddc7-e3f5-4951-9a20-397954732131}">

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Meadow Extension for Visual Studio for Windows
 
-This is the add-in for Visual Studio that enables Meadow projects to be built and deployed on Windows. 
+This is the add-in for Visual Studio 2019 and 2022 that enables Meadow projects to be built and deployed on Windows. 
 
 ## Build Status 
 

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ This is the add-in for Visual Studio that enables Meadow projects to be built an
 
 ## Getting Started
 
-The [Meadow.CLI](https://github.com/WildernessLabs/Meadow.CLI) repo must be cloned adjacent to this checkout.
+The [Meadow.CLI](https://github.com/WildernessLabs/Meadow.CLI) repo must be cloned adjacent to this checkout using the `develop` branch.
 
 ## License
 
@@ -16,4 +16,4 @@ Released under the [Apache 2 license](license.md).
 
 ## Authors
 
-Brian Kim
+Brian Kim, Adrian Stevens, Jorge Ramirez, Dominique Louis


### PR DESCRIPTION
Something like this...
![DeviceList](https://user-images.githubusercontent.com/271363/145688985-5648d8f4-40ce-42fe-9c18-7b0df8d5f814.png)

It auto-populates, but can take 10s to update. Not ideal, but better than what we currently have.

VS2019 Extension - https://github.com/WildernessLabs/VS_Win_Meadow_Extension/suites/4844867226/artifacts/137393043

VS2022 Extension - https://github.com/WildernessLabs/VS_Win_Meadow_Extension/suites/4844867226/artifacts/137393044

Once you've installed the extension, right-click the tool bar and select `Meadow Device List` for the combobox to appear. The drag where it suits you.

I've removed the MeadowWindow (Popup and Key Bindings)