### PR TITLE
Attempt to fix VS2022 build errors in CI/CD

### DIFF
--- a/VS_Meadow_Extension/VS_Meadow_Extension.2022/VS_Meadow_Extension.2022.csproj
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.2022/VS_Meadow_Extension.2022.csproj
@@ -120,7 +120,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="15.0.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.3.0.0" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.1.4057</Version>
+      <Version>17.2.2198</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Bumped a single NuGet package. We went from build error to VSIX compatibility warnings, though.