### PR TITLE
Remove broken Ms.Vs.CoreUtility references

### DIFF
--- a/Meadow.CSharp.Library.Template/Meadow.CSharp.Library.Template.csproj
+++ b/Meadow.CSharp.Library.Template/Meadow.CSharp.Library.Template.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\WildernessLabs.Meadow.Assemblies.0.1.1\lib\net45\System.dll</HintPath>
     </Reference>

--- a/Meadow.CSharp.Template/Meadow.CSharp.Template.csproj
+++ b/Meadow.CSharp.Template/Meadow.CSharp.Template.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\WildernessLabs.Meadow.Assemblies.0.1.1\lib\net45\System.dll</HintPath>
     </Reference>

--- a/Meadow.FSharp.Library.Template/Meadow.FSharp.Library.Template.csproj
+++ b/Meadow.FSharp.Library.Template/Meadow.FSharp.Library.Template.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\WildernessLabs.Meadow.Assemblies.0.1.1\lib\net45\System.dll</HintPath>
     </Reference>

--- a/Meadow.FSharp.Template/Meadow.FSharp.Template.csproj
+++ b/Meadow.FSharp.Template/Meadow.FSharp.Template.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/Meadow.VBNet.Library.Template/Meadow.VBNet.Library.Template.csproj
+++ b/Meadow.VBNet.Library.Template/Meadow.VBNet.Library.Template.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\WildernessLabs.Meadow.Assemblies.0.1.1\lib\net45\System.dll</HintPath>
     </Reference>

--- a/Meadow.VBNet.Template/Meadow.VBNet.Template.csproj
+++ b/Meadow.VBNet.Template/Meadow.VBNet.Template.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
Testing this out to see if the resulting artifacts still work as expected. These were the source of several items that _looked_ like errors when I was diagnosing the failing CI jobs.

For example, here's [one such warning from a recent CI build on develop](https://github.com/WildernessLabs/VS_Win_Meadow_Extension/runs/8053014129?check_suite_focus=true#step:8:22). And there are 25 mentions of `Microsoft.VisualStudio.CoreUtility` in that build log just for the VS2022 extension. (And another 4 mentions in the VS2019 build log.

> C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2302,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "Microsoft.VisualStudio.CoreUtility". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [D:\a\VS_Win_Meadow_Extension\VS_Win_Meadow_Extension\main\Meadow.CSharp.Library.Template\Meadow.CSharp.Library.Template.csproj]

After the CI for this PR ran, there are [no mentions of `Microsoft.VisualStudio.CoreUtility` in the two VS extension build logs](https://github.com/WildernessLabs/VS_Win_Meadow_Extension/runs/8137644538?check_suite_focus=true).