### PR TITLE
Update C# and F# library templates to set class namespace to match name

### DIFF
--- a/Meadow.CSharp.Library.Template/Class1.cs
+++ b/Meadow.CSharp.Library.Template/Class1.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace MeadowLibrary
+namespace $safeprojectname$
 {
     public class Class1
     {

--- a/Meadow.FSharp.Library.Template/Class1.fs
+++ b/Meadow.FSharp.Library.Template/Class1.fs
@@ -1,4 +1,4 @@
-﻿namespace MeadowLibrary
+﻿namespace $safeprojectname$
 
 module Say =
     let hello name = printfn "Hello %s" name


### PR DESCRIPTION
VB uses the project name by default