### PR TITLE
Fix for F# file include

### DIFF
--- a/Meadow.FSharp.Library.Template/Meadow.FSharp.Library.fsproj
+++ b/Meadow.FSharp.Library.Template/Meadow.FSharp.Library.fsproj
@@ -5,6 +5,9 @@
     <AssemblyName>MeadowLibrary</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Class1.fs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Meadow.Foundation" Version="0.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
For F#, file includes are critical since file order is important. The prior version was just spinning up an empty F# project, sadly.