### PR TITLE
Change PDBs inclusion default to false

### DIFF
--- a/VS_Meadow_Extension/VS_Meadow_Extension.Shared/DeployProvider.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.Shared/DeployProvider.cs
@@ -168,8 +168,8 @@ namespace Meadow
 
             var appPathDll = Path.Combine(folder, "App.dll");
 
-            var includePdbs = configuredProject?.ProjectConfiguration?.Dimensions["Configuration"].Contains("Debug");
-            await Meadow.DeployApp(appPathDll, includePdbs.HasValue && includePdbs.Value, token);
+            var includePdbs = false;
+            await Meadow.DeployApp(appPathDll, includePdbs, token);
         }
 
         public bool IsDeploySupported


### PR DESCRIPTION
- https://github.com/WildernessLabs/Meadow_Issues/issues/376
- https://github.com/WildernessLabs/Meadow.CLI/pull/415

Given that the PDBs are not needed for most users, since they are not necessary for basic app debugging, making the PDBs inclusion default to false should make the deployment faster, and save storage space.

For those who are interested, the PDBs deployment will be still available through the CLI `--includePdbs` flag.