### PR TITLE
Changes to bump VS to 1.9.9, to pick up CLI v1 NoLink change.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,6 @@
 name: VS4Win Extension
 env:
-  IDE_TOOLS_RELEASE_VERSION: 1.9.8
+  IDE_TOOLS_RELEASE_VERSION: 1.9.9
 
 on:
   push:

--- a/VS_Meadow_Extension/VS_Meadow_Extension.2019/source.extension.vsixmanifest
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.2019/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="VS_Meadow_Extension.ProjectType..fe358059-9487-4fe7-a01a-4b67b8231321" Version="1.9.8" Language="en-US" Publisher="Wilderness Labs" />
+        <Identity Id="VS_Meadow_Extension.ProjectType..fe358059-9487-4fe7-a01a-4b67b8231321" Version="1.9.9" Language="en-US" Publisher="Wilderness Labs" />
         <DisplayName>VS 2019 Tools for Meadow</DisplayName>
         <Description xml:space="preserve">Tools for developing Meadow applications</Description>
         <Icon>wildernesslabs_icon.png</Icon>

--- a/VS_Meadow_Extension/VS_Meadow_Extension.2022/source.extension.vsixmanifest
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.2022/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="VS_Meadow_Extension.2022.d5eb772d-2173-4795-b60b-67929a9bf12d" Version="1.9.8" Language="en-US" Publisher="Wilderness Labs" />
+        <Identity Id="VS_Meadow_Extension.2022.d5eb772d-2173-4795-b60b-67929a9bf12d" Version="1.9.9" Language="en-US" Publisher="Wilderness Labs" />
         <DisplayName>VS 2022 Tools for Meadow</DisplayName>
         <Description xml:space="preserve">Tools for developing Meadow applications</Description>
         <Icon>wildernesslabs_icon.png</Icon>

--- a/VS_Meadow_Extension/VS_Meadow_Extension.Shared/Globals.cs
+++ b/VS_Meadow_Extension/VS_Meadow_Extension.Shared/Globals.cs
@@ -9,7 +9,7 @@ namespace Meadow
 {
     public static class Globals
     {
-        public const string AssemblyVersion = "1.9.8.0";
+        public const string AssemblyVersion = "1.9.9.0";
 
         public const string MeadowCapability = "Meadow";
 

--- a/overview.md
+++ b/overview.md
@@ -4,6 +4,10 @@ For step by step instructions on using this extension, [check out the tutorial](
 
 ## Release Notes
 
+### 1.9.9
+
+- Include ProjectLab in NoLink list
+
 ### 1.9.8
 
 - Fix for right-click Deploy issue, which regressed in recent version


### PR DESCRIPTION
Trigger a build of this PR once this Meadow.CLI PR (https://github.com/WildernessLabs/Meadow.CLI/pull/584) has been merged into `develop`